### PR TITLE
Feature/Unit loading

### DIFF
--- a/deploy/gimuconfig.json
+++ b/deploy/gimuconfig.json
@@ -1,17 +1,15 @@
 {
-    "system":
-    {
-        "content_root": "./game_content",
-        "gme_sqlite_path": "./gme.sqlite",
-        "session_timeout" : 1200,
-        "mst_root": "./system"
-    },
-    "server":
-    {
-        "wallpaper_banner" : "/wallpaper/title_logo20160401.jpg",
-        "game_version": 21900,
-        "notice_url": "http://ios21900.bfww.gumi.sg/pages/versioninfo"
-    },
+  "system": {
+    "content_root": "./game_content",
+    "gme_sqlite_path": "./gme.sqlite",
+    "session_timeout": 1200,
+    "mst_root": "./system" //   "./system"
+  },
+  "server": {
+    "wallpaper_banner": "/wallpaper/title_logo20151028.jpg", // title_logo20160401
+    "game_version": 21900,
+    "notice_url": "http://ios21900.bfww.gumi.sg/pages/versioninfo"
+  },
 	"log":
 	{
 		"enable": true,

--- a/deploy/gimuconfig.json
+++ b/deploy/gimuconfig.json
@@ -3,10 +3,10 @@
     "content_root": "./game_content",
     "gme_sqlite_path": "./gme.sqlite",
     "session_timeout": 1200,
-    "mst_root": "./system" //   "./system"
+    "mst_root": "./system"
   },
   "server": {
-    "wallpaper_banner": "/wallpaper/title_logo20151028.jpg", // title_logo20160401
+    "wallpaper_banner": "/wallpaper/title_logo20151028.jpg",
     "game_version": 21900,
     "notice_url": "http://ios21900.bfww.gumi.sg/pages/versioninfo"
   },

--- a/gimuserver/db/MigrationManager_Register.cpp
+++ b/gimuserver/db/MigrationManager_Register.cpp
@@ -1,9 +1,11 @@
 #include "MigrationManager.hpp"
 #include "migrations/CreateDefaultTables.hpp"
+#include "migrations/CreateUserUnitsTable.hpp"
 
 #define ADD(x) m_migs.push_back(std::make_shared<Migrations::##x>());
 
 void MigrationManager::Register()
 {
-	ADD(CreateDefaultTables);
+    ADD(CreateDefaultTables);
+    ADD(CreateUserUnitsTable);
 }

--- a/gimuserver/db/migrations/CreateUserUnitsTable.hpp
+++ b/gimuserver/db/migrations/CreateUserUnitsTable.hpp
@@ -10,17 +10,9 @@ struct CreateUserUnitsTable : public IMigration
     {
         p->execSqlSync(
             "CREATE TABLE IF NOT EXISTS user_units ("
-            "user_id TEXT NOT NULL,"
-            "unit_id TEXT NOT NULL,"
-            "name TEXT NOT NULL,"
-            "rarity INTEGER NOT NULL,"
-            "element TEXT NOT NULL,"
-            "stats TEXT NOT NULL,"
-            "bb TEXT NOT NULL,"
-            "leader_skill TEXT,"
-            "ai TEXT,"
-            "data TEXT NOT NULL,"
-            "PRIMARY KEY (user_id, unit_id)"
+            "id INTEGER PRIMARY KEY AUTOINCREMENT," // Add: Auto-incrementing primary key as per PR comment
+            "user_id TEXT NOT NULL," // Keep: Links unit to a user
+            "unit_id TEXT NOT NULL" // Keep: Stores the unit identifier
             ");"
         );
     }

--- a/gimuserver/db/migrations/CreateUserUnitsTable.hpp
+++ b/gimuserver/db/migrations/CreateUserUnitsTable.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "../IMigration.hpp"
+#include "../DbMacro.hpp"
+
+MIGRATION_NS_BEGIN
+struct CreateUserUnitsTable : public IMigration
+{
+    virtual void execute(drogon::orm::DbClientPtr p) override
+    {
+        p->execSqlSync(
+            "CREATE TABLE IF NOT EXISTS user_units ("
+            "user_id TEXT NOT NULL,"
+            "unit_id TEXT NOT NULL,"
+            "name TEXT NOT NULL,"
+            "rarity INTEGER NOT NULL,"
+            "element TEXT NOT NULL,"
+            "stats TEXT NOT NULL,"
+            "bb TEXT NOT NULL,"
+            "leader_skill TEXT,"
+            "ai TEXT,"
+            "data TEXT NOT NULL,"
+            "PRIMARY KEY (user_id, unit_id)"
+            ");"
+        );
+    }
+
+    const char* getName() const override { return "08032025_CreateUserUnitsTable"; } // Unique migration name with date
+};
+MIGRATION_NS_END

--- a/gimuserver/gme/handlers/HomeInfoHandler.hpp
+++ b/gimuserver/gme/handlers/HomeInfoHandler.hpp
@@ -6,8 +6,8 @@ HANDLER_NS_BEGIN
 class HomeInfoHandler : public HandlerBase
 {
 public:
-	const char* GetGroupId() const override { return "NiYWKdzs"; }
-	const char* GetAesKey() const override { return "f6uOewOD"; }
+	const char* GetGroupId() const override { return "NiYWKdzs"; } // Used as a group identifying key
+	const char* GetAesKey() const override { return "f6uOewOD"; } // Used as encryption key
 	void Handle(UserInfo& user, DrogonCallback cb, const Json::Value& req) const override;
 };
 HANDLER_NS_END

--- a/gimuserver/gme/handlers/UserInfoHandler.cpp
+++ b/gimuserver/gme/handlers/UserInfoHandler.cpp
@@ -22,218 +22,402 @@
 #include "gme/response/VideoAdRegion.hpp"
 #include "gme/response/SummonerJournalUserInfo.hpp"
 #include "gme/response/SignalKey.hpp"
+#include <json/reader.h>
 
 void Handler::UserInfoHandler::Handle(UserInfo& user, DrogonCallback cb, const Json::Value& req) const
 {
-	GME_DB->execSqlAsync(
-		"SELECT level, exp, max_unit_count, max_friend_count, "
-		"zel, karma, brave_coin, max_warehouse_count, want_gift, "
-		"free_gems, paid_gems, active_deck, summon_tickets, "
-		"rainbow_coins, colosseum_tickets, active_arena_deck, "
-		"total_brave_points, avail_brave_points, energy "
-		"FROM userinfo WHERE id = $1", [this, &user, cb](const drogon::orm::Result& result) {
+    // Extract and log the initial user ID
+    std::string requestUserId = user.info.userID;
+    LOG_INFO << "UserInfoHandler: Handling request for user_id (initial): " << requestUserId;
 
-			if (result.size() > 0)
-			{
-				int col = 0;
-				auto& sql = result[0];
-				user.teamInfo.UserID = user.info.userID;
-				user.teamInfo.Level = sql[col++].as<uint32_t>();
-				user.teamInfo.Exp = sql[col++].as<int64_t>();
-				user.teamInfo.MaxUnitCount = sql[col++].as<uint32_t>();
-				user.teamInfo.MaxFriendCount = sql[col++].as<uint32_t>();
-				user.teamInfo.Zel = sql[col++].as<uint64_t>();
-				user.teamInfo.Karma = sql[col++].as<uint64_t>();
-				user.teamInfo.BraveCoin = sql[col++].as<uint32_t>();
-				user.teamInfo.WarehouseCount = sql[col++].as<uint32_t>();
-				user.teamInfo.WantGift = sql[col++].as<std::string>();
-				user.teamInfo.FreeGems = sql[col++].as<uint32_t>();
-				user.teamInfo.PaidGems = sql[col++].as<uint32_t>();
-				user.teamInfo.ActiveDeck = sql[col++].as<uint32_t>();
-				user.teamInfo.SummonTicket = sql[col++].as<uint32_t>();
-				user.teamInfo.RainbowCoin = sql[col++].as<uint32_t>();
-				user.teamInfo.ColosseumTicket = sql[col++].as<uint32_t>();
-				user.teamInfo.ArenaDeckNum = sql[col++].as<uint32_t>();
-				user.teamInfo.BravePointsTotal = sql[col++].as<uint32_t>();
-				user.teamInfo.CurrentBravePoints = sql[col++].as<uint32_t>();
-				user.teamInfo.ActionPoint = sql[col++].as<uint32_t>();
-			}
-			else
-			{
-				auto sc = System::Instance().MstConfig().StartInfo();
-				user.teamInfo.UserID = user.info.userID;
-				user.teamInfo.Level = sc.Level;
-				user.teamInfo.Exp = 0;
-				user.teamInfo.MaxUnitCount = sc.UnitCount;
-				user.teamInfo.MaxFriendCount = sc.FriendCount;
-				user.teamInfo.Zel = sc.Zel;
-				user.teamInfo.Karma = sc.Karma;
-				user.teamInfo.BraveCoin = 0;
-				user.teamInfo.WarehouseCount = sc.UnitCount;
-				user.teamInfo.FreeGems = sc.FreeGems;
-				user.teamInfo.PaidGems = sc.PaidGems;
-				user.teamInfo.SummonTicket = sc.SummonTickets;
-				user.teamInfo.ColosseumTicket = sc.ColosseumTickets;
-			}
+    // Check for user_id in the request body
+    if (req.isMember("user_id")) {
+        requestUserId = req["user_id"].asString();
+        user.info.userID = requestUserId;
+        LOG_INFO << "UserInfoHandler: Overriding user_id from request body to: " << requestUserId;
+    }
+    else if (req.isMember("ak")) { // Check for ak parameter (from login context)
+        requestUserId = req["ak"].asString();
+        user.info.userID = requestUserId;
+        LOG_INFO << "UserInfoHandler: Overriding user_id from request ak to: " << requestUserId;
+    }
+    else {
+        // Fallback: Use the user_id from the login response (hardcode for now)
+        requestUserId = "0839899613932562";
+        user.info.userID = requestUserId;
+        LOG_INFO << "UserInfoHandler: No user_id or ak in request, using hardcoded user_id: " << requestUserId;
+    }
 
-			const auto& msts = System::Instance().MstConfig();
+    // Check if this is a unit inventory or squad management request
+    std::string action = req.isMember("action") ? req["action"].asString() : "";
+    if (action == "load_unit_inventory" || action == "Zw3WIoWu" || action == "load_squad_management") {
+        GME_DB->execSqlAsync(
+            "SELECT unit_id, name, rarity, element, stats, bb, leader_skill, ai FROM user_units WHERE user_id = $1 LIMIT 500",  // LIMIT 1470 here
+            [this, &user, cb, action](const drogon::orm::Result& unitResult) {
+            LOG_INFO << "UserInfoHandler: Found " << unitResult.size() << " units for user_id: " << user.info.userID;
 
-			// setup teaminfo progression info
-			{
-				const auto& p = msts.GetProgressionInfo().Mst.at(user.teamInfo.Level - 1);
-				user.teamInfo.DeckCost = p.deckCost;
-				user.teamInfo.MaxFriendCount = p.friendCount;
-				user.teamInfo.AddFriendCount = p.addFriendCount;
-				user.teamInfo.MaxActionPoint = p.actionPoints;
+            Json::Value res;
+            Response::UserUnitInfo unitInfo;
+            for (const auto& row : unitResult) {
+                Response::UserUnitInfo::Data d;
+                d.userID = user.info.userID;
+                d.userUnitID = std::stoul(row["unit_id"].as<std::string>());
+                d.unitID = std::stoul(row["unit_id"].as<std::string>());
+                d.unitTypeID = row["rarity"].as<uint32_t>();
+                d.element = row["element"].as<std::string>();
+                d.unitLv = 1;
+                d.newFlg = 1;
+                d.receiveDate = 100;
+                d.FeBP = 100;
+                d.FeMaxUsableBP = 200;
 
-				if (user.teamInfo.ActionPoint == 0)
-					user.teamInfo.ActionPoint = user.teamInfo.MaxActionPoint;
-			}
+                Json::Value stats;
+                Json::Reader reader;
+                std::string statsStr = row["stats"].as<std::string>();
+                if (!reader.parse(statsStr, stats)) {
+                    LOG_ERROR << "Failed to parse stats JSON: " << statsStr;
+                    stats = Json::Value();
+                }
+                d.baseHp = stats.isMember("hp") ? stats["hp"].asUInt() : 1000;
+                d.baseAtk = stats.isMember("atk") ? stats["atk"].asUInt() : 1000;
+                d.baseDef = stats.isMember("def") ? stats["def"].asUInt() : 1000;
+                d.baseHeal = stats.isMember("rec") ? stats["rec"].asUInt() : 1000;
+                d.addHp = d.baseHp / 10;
+                d.addAtk = d.baseAtk / 10;
+                d.addDef = d.baseDef / 10;
+                d.addHeal = d.baseHeal / 10;
+                d.extHp = d.addHp;
+                d.extAtk = d.addAtk;
+                d.extDef = d.addDef;
+                d.extHeal = d.addHeal;
+                d.limitOverHP = d.baseHp / 5;
+                d.limitOverAtk = d.baseAtk / 5;
+                d.limitOverDef = d.baseDef / 5;
+                d.limitOverHeal = d.baseHeal / 5;
+                d.exp = 1;
+                d.totalExp = 1;
 
-			Json::Value res;
-			user.info.Serialize(res);
-			user.teamInfo.Serialize(res);
+                unitInfo.Mst.emplace_back(d);
+            }
 
-			{
-				Response::UserLoginCampaignInfo v;
-				v.currentDay = 1;
-				v.totalDays = 96;
-				v.firstForTheDay = true;
-				v.Serialize(res);
-			}
+            // Fallback: Add a dummy unit if inventory is empty (to prevent crashes)
+            if (unitInfo.Mst.empty()) {
+                LOG_WARN << "UserInfoHandler: No units found, adding dummy unit for compatibility";
+                Response::UserUnitInfo::Data d;
+                d.userID = user.info.userID;
+                d.userUnitID = 9999;
+                d.unitID = 9999;
+                d.unitTypeID = 1;
+                d.element = "fire";
+                d.unitLv = 1;
+                d.newFlg = 1;
+                d.receiveDate = 100;
+                d.FeBP = 100;
+                d.FeMaxUsableBP = 200;
+                d.baseHp = 1000;
+                d.baseAtk = 1000;
+                d.baseDef = 1000;
+                d.baseHeal = 1000;
+                d.addHp = 100;
+                d.addAtk = 100;
+                d.addDef = 100;
+                d.addHeal = 100;
+                d.extHp = 100;
+                d.extAtk = 100;
+                d.extDef = 100;
+                d.extHeal = 100;
+                d.limitOverHP = 200;
+                d.limitOverAtk = 200;
+                d.limitOverDef = 200;
+                d.limitOverHeal = 200;
+                d.exp = 1;
+                d.totalExp = 1;
+                unitInfo.Mst.emplace_back(d);
+            }
 
-			{
-				Response::UserTeamArchive v;
-				v.Serialize(res);
-			}
+            unitInfo.Serialize(res);
 
-			{
-				Response::UserTeamArenaArchive v;
-				v.Serialize(res);
-			}
+            // Initialize party with the first unit to avoid Empty_Party_Info
+            Response::UserPartyDeckInfo deckInfo;
+            if (!unitInfo.Mst.empty()) {
+                Response::UserPartyDeckInfo::Data d;
+                d.deckNum = 0;
+                d.deckType = 1;
+                d.dispOrder = 0;
+                d.memberType = 0; // Leader
+                d.userUnitID = unitInfo.Mst[0].userUnitID;
+                deckInfo.Mst.emplace_back(d);
+            }
+            deckInfo.Serialize(res);
 
-			{
-				Response::UserUnitInfo v;
-				Response::UserUnitInfo::Data d;
-				d.userID = user.info.userID;
-				d.userUnitID = 1;
-				d.unitTypeID = 1;
-				
-				d.baseHp = 1000;
-				d.addHp = 1001;
-				d.extHp = 1002;
+            cb(newGmeOkResponse(GetGroupId(), GetAesKey(), res));
+            return;
+        },
+            [this, cb](const drogon::orm::DrogonDbException& e) { OnError(e, cb); },
+            user.info.userID
+        );
+        return;
+    }
 
-				d.baseDef = 1100;
-				d.addDef = 1101;
-				d.extDef = 1102;
+    // Original logic for initial load
+    GME_DB->execSqlAsync(
+        "SELECT level, exp, max_unit_count, max_friend_count, "
+        "zel, karma, brave_coin, max_warehouse_count, want_gift, "
+        "free_gems, paid_gems, active_deck, summon_tickets, "
+        "rainbow_coins, colosseum_tickets, active_arena_deck, "
+        "total_brave_points, avail_brave_points, energy "
+        "FROM userinfo WHERE id = $1",
+        [this, &user, cb](const drogon::orm::Result& result) {
+        if (result.size() > 0) {
+            int col = 0;
+            auto& sql = result[0];
+            user.teamInfo.UserID = user.info.userID;
+            user.teamInfo.Level = sql[col++].as<uint32_t>();
+            user.teamInfo.Exp = sql[col++].as<int64_t>();
+            user.teamInfo.MaxUnitCount = sql[col++].as<uint32_t>();
+            user.teamInfo.MaxFriendCount = sql[col++].as<uint32_t>();
+            user.teamInfo.Zel = sql[col++].as<uint64_t>();
+            user.teamInfo.Karma = sql[col++].as<uint64_t>();
+            user.teamInfo.BraveCoin = sql[col++].as<uint32_t>();
+            user.teamInfo.WarehouseCount = sql[col++].as<uint32_t>();
+            user.teamInfo.WantGift = sql[col++].as<std::string>();
+            user.teamInfo.FreeGems = sql[col++].as<uint32_t>();
+            user.teamInfo.PaidGems = sql[col++].as<uint32_t>();
+            user.teamInfo.ActiveDeck = sql[col++].as<uint32_t>();
+            user.teamInfo.SummonTicket = sql[col++].as<uint32_t>();
+            user.teamInfo.RainbowCoin = sql[col++].as<uint32_t>();
+            user.teamInfo.ColosseumTicket = sql[col++].as<uint32_t>();
+            user.teamInfo.ArenaDeckNum = sql[col++].as<uint32_t>();
+            user.teamInfo.BravePointsTotal = sql[col++].as<uint32_t>();
+            user.teamInfo.CurrentBravePoints = sql[col++].as<uint32_t>();
+            user.teamInfo.ActionPoint = sql[col++].as<uint32_t>();
+        }
+        else {
+            auto sc = System::Instance().MstConfig().StartInfo();
+            user.teamInfo.UserID = user.info.userID;
+            user.teamInfo.Level = sc.Level;
+            user.teamInfo.Exp = 0;
+            user.teamInfo.MaxUnitCount = 2292; // Updated to match unit count
+            user.teamInfo.MaxFriendCount = sc.FriendCount;
+            user.teamInfo.Zel = sc.Zel;
+            user.teamInfo.Karma = sc.Karma;
+            user.teamInfo.BraveCoin = 0;
+            user.teamInfo.WarehouseCount = 2292; // Updated to match unit count
+            user.teamInfo.FreeGems = sc.FreeGems;
+            user.teamInfo.PaidGems = sc.PaidGems;
+            user.teamInfo.SummonTicket = sc.SummonTickets;
+            user.teamInfo.ColosseumTicket = sc.ColosseumTickets;
 
-				d.baseHeal = 1200;
-				d.addHeal = 1201;
-				d.extHeal = 1202;
+            // Insert default userinfo to simulate proper login flow
+            GME_DB->execSqlAsync(
+                "INSERT INTO userinfo (id, level, exp, max_unit_count, max_friend_count, zel, karma, brave_coin, max_warehouse_count, want_gift, free_gems, paid_gems, active_deck, summon_tickets, rainbow_coins, colosseum_tickets, active_arena_deck, total_brave_points, avail_brave_points, energy) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
+                [](const drogon::orm::Result& result) {
+                LOG_INFO << "UserInfoHandler: Inserted default userinfo for new user";
+            },
+                [](const drogon::orm::DrogonDbException& e) {
+                LOG_ERROR << "UserInfoHandler: Failed to insert default userinfo: " << e.base().what();
+            },
+                user.info.userID, user.teamInfo.Level, user.teamInfo.Exp, user.teamInfo.MaxUnitCount, user.teamInfo.MaxFriendCount,
+                user.teamInfo.Zel, user.teamInfo.Karma, user.teamInfo.BraveCoin, user.teamInfo.WarehouseCount, user.teamInfo.WantGift,
+                user.teamInfo.FreeGems, user.teamInfo.PaidGems, user.teamInfo.ActiveDeck, user.teamInfo.SummonTicket, user.teamInfo.RainbowCoin,
+                user.teamInfo.ColosseumTicket, user.teamInfo.ArenaDeckNum, user.teamInfo.BravePointsTotal, user.teamInfo.CurrentBravePoints, user.teamInfo.ActionPoint
+            );
+        }
 
-				d.baseAtk = 1300;
-				d.addAtk = 1301;
-				d.extAtk = 1302;
+        const auto& msts = System::Instance().MstConfig();
+        {
+            const auto& p = msts.GetProgressionInfo().Mst.at(user.teamInfo.Level - 1);
+            user.teamInfo.DeckCost = p.deckCost;
+            user.teamInfo.MaxFriendCount = p.friendCount;
+            user.teamInfo.AddFriendCount = p.addFriendCount;
+            user.teamInfo.MaxActionPoint = p.actionPoints;
+            if (user.teamInfo.ActionPoint == 0)
+                user.teamInfo.ActionPoint = user.teamInfo.MaxActionPoint;
+        }
 
-				d.limitOverAtk = 1400;
-				d.limitOverDef = 1401;
-				d.limitOverHeal = 1402;
-				d.limitOverHP = 1403;
+        GME_DB->execSqlAsync(
+            "SELECT unit_id, name, rarity, element, stats, bb, leader_skill, ai FROM user_units WHERE user_id = $1 LIMIT 500", // LIMIT 1470 here at end
+            [this, &user, cb](const drogon::orm::Result& unitResult) {
+            LOG_INFO << "UserInfoHandler: Found " << unitResult.size() << " units for user_id: " << user.info.userID;
 
-				d.element = 1;
-				d.unitLv = 1;
-				d.newFlg = 1;
+            Json::Value res;
+            user.info.Serialize(res);
+            user.teamInfo.Serialize(res);
 
-				d.extCnt = 1500;
-				d.receiveDate = 100;
-				d.FeBP = 100;
-				d.FeUsedBP = 0;
-				d.FeMaxUsableBP = 200;
-				d.UnitImgType = 0;
+            {
+                Response::UserLoginCampaignInfo v;
+                v.currentDay = 1;
+                v.totalDays = 96;
+                v.firstForTheDay = true;
+                v.Serialize(res);
+            }
 
+            {
+                Response::UserTeamArchive v;
+                v.Serialize(res);
+            }
 
-				d.exp = 1;
-				d.totalExp = 1;
+            {
+                Response::UserTeamArenaArchive v;
+                v.Serialize(res);
+            }
 
-				d.unitID = 50253;
-				v.Mst.emplace_back(d);
-				v.Serialize(res);
-			}
+            Response::UserUnitInfo unitInfo;
+            for (const auto& row : unitResult) {
+                Response::UserUnitInfo::Data d;
+                d.userID = user.info.userID;
+                d.userUnitID = std::stoul(row["unit_id"].as<std::string>());
+                d.unitID = std::stoul(row["unit_id"].as<std::string>());
+                d.unitTypeID = row["rarity"].as<uint32_t>();
+                d.element = row["element"].as<std::string>();
+                d.unitLv = 1;
+                d.newFlg = 1;
+                d.receiveDate = 100;
+                d.FeBP = 100;
+                d.FeMaxUsableBP = 200;
 
-			{
-				Response::UserPartyDeckInfo v;
+                Json::Value stats;
+                Json::Reader reader;
+                std::string statsStr = row["stats"].as<std::string>();
+                if (!reader.parse(statsStr, stats)) {
+                    LOG_ERROR << "Failed to parse stats JSON: " << statsStr;
+                    stats = Json::Value();
+                }
+                d.baseHp = stats.isMember("hp") ? stats["hp"].asUInt() : 1000;
+                d.baseAtk = stats.isMember("atk") ? stats["atk"].asUInt() : 1000;
+                d.baseDef = stats.isMember("def") ? stats["def"].asUInt() : 1000;
+                d.baseHeal = stats.isMember("rec") ? stats["rec"].asUInt() : 1000;
+                d.addHp = d.baseHp / 10;
+                d.addAtk = d.baseAtk / 10;
+                d.addDef = d.baseDef / 10;
+                d.addHeal = d.baseHeal / 10;
+                d.extHp = d.addHp;
+                d.extAtk = d.addAtk;
+                d.extDef = d.addDef;
+                d.extHeal = d.addHeal;
+                d.limitOverHP = d.baseHp / 5;
+                d.limitOverAtk = d.baseAtk / 5;
+                d.limitOverDef = d.baseDef / 5;
+                d.limitOverHeal = d.baseHeal / 5;
+                d.exp = 1;
+                d.totalExp = 1;
 
-				for (int i = 0; i < 10; i++)
-				{
-					Response::UserPartyDeckInfo::Data d;
-					d.deckNum = i;
-					d.deckType = 1; // 1 = party
-					d.dispOrder = 0; // unit position
-					d.memberType = 0; // 0 = leader, 1 = normal
-					d.userUnitID = 1;
-					v.Mst.emplace_back(d);
-				}
-				v.Serialize(res);
-			}
+                unitInfo.Mst.emplace_back(d);
+            }
 
-			{
-				Response::UserUnitDictionary v;
-				v.Serialize(res);
-			}
+            // Fallback: Add a dummy unit if inventory is empty
+            if (unitInfo.Mst.empty()) {
+                LOG_WARN << "UserInfoHandler: No units found, adding dummy unit for compatibility";
+                Response::UserUnitInfo::Data d;
+                d.userID = user.info.userID;
+                d.userUnitID = 9999;
+                d.unitID = 9999;
+                d.unitTypeID = 1;
+                d.element = "fire";
+                d.unitLv = 1;
+                d.newFlg = 1;
+                d.receiveDate = 100;
+                d.FeBP = 100;
+                d.FeMaxUsableBP = 200;
+                d.baseHp = 1000;
+                d.baseAtk = 1000;
+                d.baseDef = 1000;
+                d.baseHeal = 1000;
+                d.addHp = 100;
+                d.addAtk = 100;
+                d.addDef = 100;
+                d.addHeal = 100;
+                d.extHp = 100;
+                d.extAtk = 100;
+                d.extDef = 100;
+                d.extHeal = 100;
+                d.limitOverHP = 200;
+                d.limitOverAtk = 200;
+                d.limitOverDef = 200;
+                d.limitOverHeal = 200;
+                d.exp = 1;
+                d.totalExp = 1;
+                unitInfo.Mst.emplace_back(d);
+            }
 
-			{
-				Response::UserFavorite v;
-				v.Serialize(res);
-			}
+            unitInfo.Serialize(res);
 
-			{
-				Response::UserClearMissionInfo v;
-				v.Serialize(res);
-			}
+            {
+                Response::UserPartyDeckInfo deckInfo;
+                if (!unitInfo.Mst.empty()) {
+                    Response::UserPartyDeckInfo::Data d;
+                    d.deckNum = 0;
+                    d.deckType = 1;
+                    d.dispOrder = 0;
+                    d.memberType = 0; // Leader
+                    d.userUnitID = unitInfo.Mst[0].userUnitID;
+                    deckInfo.Mst.emplace_back(d);
+                }
+                deckInfo.Serialize(res);
+            }
 
-			{
-				Response::UserWarehouseInfo v;
-				v.Serialize(res);
-			}
+            {
+                Response::UserUnitDictionary v;
+                v.Serialize(res);
+            }
 
-			{
-				Response::ItemFavorite v;
-				v.Serialize(res);
-			}
+            {
+                Response::UserFavorite v;
+                v.Serialize(res);
+            }
 
-			{
-				Response::UserItemDictionaryInfo v;
-				v.Serialize(res);
-			}
+            {
+                Response::UserClearMissionInfo v;
+                v.Serialize(res);
+            }
 
-			{
-				Response::UserArenaInfo v;
-				v.Serialize(res);
-			}
+            {
+                Response::UserWarehouseInfo v;
+                v.Serialize(res);
+            }
 
-			{
-				Response::UserGiftInfo v;
-				v.Serialize(res);
-			}
+            {
+                Response::ItemFavorite v;
+                v.Serialize(res);
+            }
 
-			{
-				// SummonerJournal
-				Response::SummonerJournalUserInfo v;
-				v.userId = user.info.userID;
-				v.Serialize(res);
-			}
+            {
+                Response::UserItemDictionaryInfo v;
+                v.Serialize(res);
+            }
 
-			{
-				Response::SignalKey v;
-				v.key = "5EdKHavF";
-				v.Serialize(res);
-			}
+            {
+                Response::UserArenaInfo v;
+                v.Serialize(res);
+            }
 
-			System::Instance().MstConfig().CopyUserInfoMstTo(res);
+            {
+                Response::UserGiftInfo v;
+                v.Serialize(res);
+            }
 
-			cb(newGmeOkResponse(GetGroupId(), GetAesKey(), res));
-		}, 
-		[this, cb](const drogon::orm::DrogonDbException& e) { OnError(e, cb); },
-		user.info.userID
-	);
+            {
+                Response::SummonerJournalUserInfo v;
+                v.userId = user.info.userID;
+                v.Serialize(res);
+            }
+
+            {
+                Response::SignalKey v;
+                v.key = "5EdKHavF";
+                v.Serialize(res);
+            }
+
+            System::Instance().MstConfig().CopyUserInfoMstTo(res);
+
+            cb(newGmeOkResponse(GetGroupId(), GetAesKey(), res));
+        },
+            [this, cb](const drogon::orm::DrogonDbException& e) { OnError(e, cb); },
+            user.info.userID
+        );
+    },
+        [this, cb](const drogon::orm::DrogonDbException& e) { OnError(e, cb); },
+        user.info.userID
+    );
 }

--- a/gimuserver/gme/handlers/UserInfoHandler.cpp
+++ b/gimuserver/gme/handlers/UserInfoHandler.cpp
@@ -53,7 +53,7 @@ void Handler::UserInfoHandler::Handle(UserInfo& user, DrogonCallback cb, const J
     if (action == "load_unit_inventory" || action == "Zw3WIoWu" || action == "load_squad_management") {
         GME_DB->execSqlAsync(
             // Updated query to match new user_units schema
-            "SELECT id, unit_id FROM user_units WHERE user_id = $1 LIMIT 4000",  // LIMIT 1485 here
+            "SELECT id, unit_id FROM user_units WHERE user_id = $1 LIMIT 4000",  // Set the limit of how many units are allowed. Kept this code to prevent errors later hopefully.
             [this, &user, cb, action](const drogon::orm::Result& unitResult) {
             LOG_INFO << "UserInfoHandler: Found " << unitResult.size() << " units for user_id: " << user.info.userID;
 
@@ -258,7 +258,7 @@ void Handler::UserInfoHandler::Handle(UserInfo& user, DrogonCallback cb, const J
 
         GME_DB->execSqlAsync(
             // Updated query to match new user_units schema
-            "SELECT id, unit_id FROM user_units WHERE user_id = $1 LIMIT 4000", // LIMIT 1485 here at end
+            "SELECT id, unit_id FROM user_units WHERE user_id = $1 LIMIT 4000", // Set the limit of how many units are allowed. Kept this code to prevent errors later hopefully.
             [this, &user, cb](const drogon::orm::Result& unitResult) {
             LOG_INFO << "UserInfoHandler: Found " << unitResult.size() << " units for user_id: " << user.info.userID;
 

--- a/gimuserver/gumiapi/AccountController.cpp
+++ b/gimuserver/gumiapi/AccountController.cpp
@@ -8,7 +8,7 @@ void AccountController::HandleGuest(const HttpRequestPtr& rq, std::function<void
 
     // Extract parameters
     auto params = rq->getParameters();
-    std::string userId = params["ak"].empty() ? "default_user_id" : params["ak"]; // Use 'ak' as userId (e.g., 0101AABB or 0839899613932562)
+    std::string userId = params["ak"].empty() ? "Developer" : params["ak"]; // Use 'ak' as userId (e.g., 0101AABB or 0839899613932562) default_user_id
     std::string deviceId = params["device_id"].empty() ? "unknown_device" : params["device_id"];
 
     // Check if user exists in users table
@@ -37,8 +37,8 @@ void AccountController::HandleGuest(const HttpRequestPtr& rq, std::function<void
                 [](const drogon::orm::DrogonDbException& e) {
                 LOG_ERROR << "AccountController: Failed to insert default userinfo: " << e.base().what();
             },
-                userId, 1, 0, 2292, 50, 1000, 0, 0, 2292, "", 100, 0, 0, 0, 0, 0, 0, 0, 0, 15
-            );
+                userId, 999, 0, 4000, 50, 99000000, 99000000, 4200, 5500, "", 10000, 20000, 0, 99, 0, 0, 0, 0, 0, 431
+            ); // Sets new user values if no gme.sqlite exists :)
         }
 
         // Return login response

--- a/gimuserver/gumiapi/AccountController.cpp
+++ b/gimuserver/gumiapi/AccountController.cpp
@@ -1,14 +1,60 @@
 #include "AccountController.hpp"
 #include "core/Utils.hpp"
+#include <db/DbMacro.hpp>
 
 void AccountController::HandleGuest(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
 {
-	Utils::DumpInfoToDrogon(rq, "AccountController");
+    Utils::DumpInfoToDrogon(rq, "AccountController");
 
-	Json::Value v;
-	v["status"] = "successful"; // "error" if in error
-	v["token"] = "test_token"; // TODO: use sqlite as database
-	v["game_user_id"] = "5484848548548"; // TODO: use sqlite as database
-	v["status_no"] = "0";
-	callback(HttpResponse::newHttpJsonResponse(v));
+    // Extract parameters
+    auto params = rq->getParameters();
+    std::string userId = params["ak"].empty() ? "default_user_id" : params["ak"]; // Use 'ak' as userId (e.g., 0101AABB or 0839899613932562)
+    std::string deviceId = params["device_id"].empty() ? "unknown_device" : params["device_id"];
+
+    // Check if user exists in users table
+    GME_DB->execSqlAsync(
+        "SELECT id FROM users WHERE id = $1",
+        [this, userId, deviceId, callback](const drogon::orm::Result& result) {
+        if (result.empty()) {
+            // New user: Insert into users and userinfo
+            GME_DB->execSqlAsync(
+                "INSERT INTO users (id, account_id, username, admin) VALUES ($1, $2, $3, $4)",
+                [](const drogon::orm::Result& result) {
+                LOG_INFO << "AccountController: Inserted new user";
+            },
+                [](const drogon::orm::DrogonDbException& e) {
+                LOG_ERROR << "AccountController: Failed to insert new user: " << e.base().what();
+            },
+                userId, deviceId, "GuestUser", 0
+            );
+
+            GME_DB->execSqlAsync(
+                "INSERT INTO userinfo (id, level, exp, max_unit_count, max_friend_count, zel, karma, brave_coin, max_warehouse_count, want_gift, free_gems, paid_gems, active_deck, summon_tickets, rainbow_coins, colosseum_tickets, active_arena_deck, total_brave_points, avail_brave_points, energy) "
+                "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20)",
+                [](const drogon::orm::Result& result) {
+                LOG_INFO << "AccountController: Inserted default userinfo for new user";
+            },
+                [](const drogon::orm::DrogonDbException& e) {
+                LOG_ERROR << "AccountController: Failed to insert default userinfo: " << e.base().what();
+            },
+                userId, 1, 0, 2292, 50, 1000, 0, 0, 2292, "", 100, 0, 0, 0, 0, 0, 0, 0, 0, 15
+            );
+        }
+
+        // Return login response
+        Json::Value v;
+        v["status"] = "successful";
+        v["token"] = "test_token"; // TODO: Generate a proper token
+        v["game_user_id"] = userId; // Use the same userId as in the database
+        v["status_no"] = "0";
+        callback(HttpResponse::newHttpJsonResponse(v));
+    },
+        [callback](const drogon::orm::DrogonDbException& e) {
+        LOG_ERROR << "AccountController: Database error during login: " << e.base().what();
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setStatusCode(k500InternalServerError);
+        callback(resp);
+    },
+        userId
+    );
 }

--- a/gimuserver/static_web/BfWebController.cpp
+++ b/gimuserver/static_web/BfWebController.cpp
@@ -4,35 +4,183 @@
 #include "WebTerms.hpp"
 
 #include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <vector>
 
 using namespace drogon;
 namespace fs = std::filesystem;
 
+bool hasExtension(const std::string& path, const std::string& ext) {
+    size_t pos = path.find(ext);
+    return pos != std::string::npos && pos == path.length() - ext.length();
+}
+
+// Parse dimensions from filename (e.g., "MapVillage_640x0809.png" -> 640, 809)
+bool parseDimensions(const std::string& filename, int& width, int& height) {
+    size_t lastUnderscore = filename.find_last_of('_');
+    size_t dotPos = filename.find_last_of('.');
+    if (lastUnderscore == std::string::npos || dotPos == std::string::npos || lastUnderscore >= dotPos) {
+        return false;
+    }
+
+    std::string dimStr = filename.substr(lastUnderscore + 1, dotPos - lastUnderscore - 1);
+    size_t xPos = dimStr.find('x');
+    if (xPos == std::string::npos) return false;
+
+    try {
+        width = std::stoi(dimStr.substr(0, xPos));
+        height = std::stoi(dimStr.substr(xPos + 1));
+        return true;
+    }
+    catch (...) {
+        return false;
+    }
+}
+
+// Generate a minimal PNG with specified dimensions
+std::vector<char> generatePlaceholderPng(int width, int height) {
+    std::vector<char> pngData;
+
+    // PNG signature
+    const char signature[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    pngData.insert(pngData.end(), signature, signature + 8);
+
+    // IHDR chunk
+    uint32_t ihdrLength = 13;
+    ihdrLength = htonl(ihdrLength);
+    pngData.insert(pngData.end(), (char*)&ihdrLength, (char*)&ihdrLength + 4);
+    const char ihdrType[] = "IHDR";
+    pngData.insert(pngData.end(), ihdrType, ihdrType + 4);
+
+    uint32_t w = htonl(width);
+    uint32_t h = htonl(height);
+    pngData.insert(pngData.end(), (char*)&w, (char*)&w + 4);
+    pngData.insert(pngData.end(), (char*)&h, (char*)&h + 4);
+
+    const char ihdrData[] = { 8, 2, 0, 0, 0 }; // Bit depth 8, RGB, no compression, filter, interlace
+    pngData.insert(pngData.end(), ihdrData, ihdrData + 5);
+
+    uint32_t ihdrCrc = 0; // Simplified CRC (client may not check)
+    ihdrCrc = htonl(ihdrCrc);
+    pngData.insert(pngData.end(), (char*)&ihdrCrc, (char*)&ihdrCrc + 4);
+
+    // IDAT chunk (minimal data for a blank image)
+    uint32_t idatLength = 12;
+    idatLength = htonl(idatLength);
+    pngData.insert(pngData.end(), (char*)&idatLength, (char*)&idatLength + 4);
+    const char idatType[] = "IDAT";
+    pngData.insert(pngData.end(), idatType, idatType + 4);
+
+    // Minimal data: 1 scanline of transparent pixels (RGBA)
+    std::vector<char> idatData;
+    idatData.push_back(0); // Filter type
+    for (int x = 0; x < width; ++x) {
+        idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); // Transparent pixel
+    }
+    for (int y = 1; y < height; ++y) {
+        idatData.push_back(0);
+        for (int x = 0; x < width; ++x) {
+            idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); idatData.push_back(0);
+        }
+    }
+    // Simplified compression (no real zlib compression)
+    pngData.insert(pngData.end(), idatData.begin(), idatData.end());
+
+    uint32_t idatCrc = 0;
+    idatCrc = htonl(idatCrc);
+    pngData.insert(pngData.end(), (char*)&idatCrc, (char*)&idatCrc + 4);
+
+    // IEND chunk
+    uint32_t iendLength = 0;
+    iendLength = htonl(iendLength);
+    pngData.insert(pngData.end(), (char*)&iendLength, (char*)&iendLength + 4);
+    const char iendType[] = "IEND";
+    pngData.insert(pngData.end(), iendType, iendType + 4);
+    uint32_t iendCrc = 0;
+    iendCrc = htonl(iendCrc);
+    pngData.insert(pngData.end(), (char*)&iendCrc, (char*)&iendCrc + 4);
+
+    return pngData;
+}
+
 void BfWebController::HandleWebPage(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
 {
-	Utils::DumpInfoToDrogon(rq, "WebController");
+    Utils::DumpInfoToDrogon(rq, "WebController");
 
-	if (rq->getPath() == "/bf/web/terms.htm")
-	{
-		// TODO: convert this to a drogon view controller
-		callback(HttpResponse::newFileResponse((const unsigned char*)WEB_TERMS_DATA, strlen(WEB_TERMS_DATA)));
-		return;
-	}
+    if (rq->getPath() == "/bf/web/terms.htm") {
+        callback(HttpResponse::newFileResponse((const unsigned char*)WEB_TERMS_DATA, strlen(WEB_TERMS_DATA)));
+        return;
+    }
 
-	auto path = System::Instance().GetContentRootPath() + rq->getPath();
+    auto path = System::Instance().GetContentRootPath() + rq->getPath();
+    LOG_INFO << "Requesting path: " << path;
 
-	if (!fs::exists(path) || fs::is_directory(path))
-	{
-		Utils::AddMissingDlcFile(rq->getPath());
-		callback(HttpResponse::newNotFoundResponse());
-		return;
-	}
+    if (fs::exists(path) && !fs::is_directory(path)) {
+        LOG_INFO << "Serving existing file: " << path;
+        auto resp = HttpResponse::newFileResponse(path);
+        if (hasExtension(path, ".png")) resp->setContentTypeCode(CT_IMAGE_PNG);
+        else if (hasExtension(path, ".csv")) resp->setContentTypeCode(CT_TEXT_CSV);
+        else if (hasExtension(path, ".dat")) resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
+        else resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
+        callback(resp);
+        return;
+    }
 
-	callback(HttpResponse::newFileResponse(path));
+    Utils::AddMissingDlcFile(rq->getPath());
+    LOG_INFO << "Generating placeholder for: " << path;
+
+    try {
+        fs::path dirPath = path.substr(0, path.find_last_of('/'));
+        if (!dirPath.empty() && !fs::exists(dirPath)) {
+            fs::create_directories(dirPath);
+        }
+
+        std::ofstream outFile(path, std::ios::binary);
+        if (outFile.is_open()) {
+            if (hasExtension(path, ".png")) {
+                std::string filename = rq->getPath().substr(rq->getPath().find_last_of('/') + 1);
+                int width = 1, height = 1;
+                parseDimensions(filename, width, height);
+                auto placeholderPng = generatePlaceholderPng(width, height);
+                outFile.write(placeholderPng.data(), placeholderPng.size());
+            }
+            else if (hasExtension(path, ".csv")) {
+                std::string placeholderCsv = "placeholder,data\n1,2";
+                outFile.write(placeholderCsv.data(), placeholderCsv.size());
+            }
+            else if (hasExtension(path, ".dat")) {
+                std::string placeholderDat = "placeholder_binary_data";
+                outFile.write(placeholderDat.data(), placeholderDat.size());
+            }
+            else {
+                std::string placeholderGeneric = "placeholder";
+                outFile.write(placeholderGeneric.data(), placeholderGeneric.size());
+            }
+            outFile.close();
+            LOG_INFO << "Generated placeholder for: " << path;
+        }
+        else {
+            LOG_ERROR << "Failed to create placeholder: " << path;
+            callback(HttpResponse::newNotFoundResponse());
+            return;
+        }
+
+        auto resp = HttpResponse::newFileResponse(path);
+        if (hasExtension(path, ".png")) resp->setContentTypeCode(CT_IMAGE_PNG);
+        else if (hasExtension(path, ".csv")) resp->setContentTypeCode(CT_TEXT_CSV);
+        else if (hasExtension(path, ".dat")) resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
+        else resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
+        callback(resp);
+    }
+    catch (const std::exception& e) {
+        LOG_ERROR << "Error generating placeholder: " << e.what();
+        callback(HttpResponse::newNotFoundResponse());
+    }
 }
 
 void BfWebController::HandleDefault(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
 {
-	Utils::DumpInfoToDrogon(rq, "WebController");
-	callback(HttpResponse::newHttpResponse());
+    Utils::DumpInfoToDrogon(rq, "WebController");
+    callback(HttpResponse::newHttpResponse());
 }

--- a/gimuserver/static_web/BfWebController.cpp
+++ b/gimuserver/static_web/BfWebController.cpp
@@ -4,183 +4,35 @@
 #include "WebTerms.hpp"
 
 #include <filesystem>
-#include <fstream>
-#include <sstream>
-#include <vector>
 
 using namespace drogon;
 namespace fs = std::filesystem;
 
-bool hasExtension(const std::string& path, const std::string& ext) {
-    size_t pos = path.find(ext);
-    return pos != std::string::npos && pos == path.length() - ext.length();
-}
-
-// Parse dimensions from filename (e.g., "MapVillage_640x0809.png" -> 640, 809)
-bool parseDimensions(const std::string& filename, int& width, int& height) {
-    size_t lastUnderscore = filename.find_last_of('_');
-    size_t dotPos = filename.find_last_of('.');
-    if (lastUnderscore == std::string::npos || dotPos == std::string::npos || lastUnderscore >= dotPos) {
-        return false;
-    }
-
-    std::string dimStr = filename.substr(lastUnderscore + 1, dotPos - lastUnderscore - 1);
-    size_t xPos = dimStr.find('x');
-    if (xPos == std::string::npos) return false;
-
-    try {
-        width = std::stoi(dimStr.substr(0, xPos));
-        height = std::stoi(dimStr.substr(xPos + 1));
-        return true;
-    }
-    catch (...) {
-        return false;
-    }
-}
-
-// Generate a minimal PNG with specified dimensions
-std::vector<char> generatePlaceholderPng(int width, int height) {
-    std::vector<char> pngData;
-
-    // PNG signature
-    const char signature[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
-    pngData.insert(pngData.end(), signature, signature + 8);
-
-    // IHDR chunk
-    uint32_t ihdrLength = 13;
-    ihdrLength = htonl(ihdrLength);
-    pngData.insert(pngData.end(), (char*)&ihdrLength, (char*)&ihdrLength + 4);
-    const char ihdrType[] = "IHDR";
-    pngData.insert(pngData.end(), ihdrType, ihdrType + 4);
-
-    uint32_t w = htonl(width);
-    uint32_t h = htonl(height);
-    pngData.insert(pngData.end(), (char*)&w, (char*)&w + 4);
-    pngData.insert(pngData.end(), (char*)&h, (char*)&h + 4);
-
-    const char ihdrData[] = { 8, 2, 0, 0, 0 }; // Bit depth 8, RGB, no compression, filter, interlace
-    pngData.insert(pngData.end(), ihdrData, ihdrData + 5);
-
-    uint32_t ihdrCrc = 0; // Simplified CRC (client may not check)
-    ihdrCrc = htonl(ihdrCrc);
-    pngData.insert(pngData.end(), (char*)&ihdrCrc, (char*)&ihdrCrc + 4);
-
-    // IDAT chunk (minimal data for a blank image)
-    uint32_t idatLength = 12;
-    idatLength = htonl(idatLength);
-    pngData.insert(pngData.end(), (char*)&idatLength, (char*)&idatLength + 4);
-    const char idatType[] = "IDAT";
-    pngData.insert(pngData.end(), idatType, idatType + 4);
-
-    // Minimal data: 1 scanline of transparent pixels (RGBA)
-    std::vector<char> idatData;
-    idatData.push_back(0); // Filter type
-    for (int x = 0; x < width; ++x) {
-        idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); // Transparent pixel
-    }
-    for (int y = 1; y < height; ++y) {
-        idatData.push_back(0);
-        for (int x = 0; x < width; ++x) {
-            idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); idatData.push_back(0);
-        }
-    }
-    // Simplified compression (no real zlib compression)
-    pngData.insert(pngData.end(), idatData.begin(), idatData.end());
-
-    uint32_t idatCrc = 0;
-    idatCrc = htonl(idatCrc);
-    pngData.insert(pngData.end(), (char*)&idatCrc, (char*)&idatCrc + 4);
-
-    // IEND chunk
-    uint32_t iendLength = 0;
-    iendLength = htonl(iendLength);
-    pngData.insert(pngData.end(), (char*)&iendLength, (char*)&iendLength + 4);
-    const char iendType[] = "IEND";
-    pngData.insert(pngData.end(), iendType, iendType + 4);
-    uint32_t iendCrc = 0;
-    iendCrc = htonl(iendCrc);
-    pngData.insert(pngData.end(), (char*)&iendCrc, (char*)&iendCrc + 4);
-
-    return pngData;
-}
-
 void BfWebController::HandleWebPage(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
 {
-    Utils::DumpInfoToDrogon(rq, "WebController");
+	Utils::DumpInfoToDrogon(rq, "WebController");
 
-    if (rq->getPath() == "/bf/web/terms.htm") {
-        callback(HttpResponse::newFileResponse((const unsigned char*)WEB_TERMS_DATA, strlen(WEB_TERMS_DATA)));
-        return;
-    }
+	if (rq->getPath() == "/bf/web/terms.htm")
+	{
+		// TODO: convert this to a drogon view controller
+		callback(HttpResponse::newFileResponse((const unsigned char*)WEB_TERMS_DATA, strlen(WEB_TERMS_DATA)));
+		return;
+	}
 
-    auto path = System::Instance().GetContentRootPath() + rq->getPath();
-    LOG_INFO << "Requesting path: " << path;
+	auto path = System::Instance().GetContentRootPath() + rq->getPath();
 
-    if (fs::exists(path) && !fs::is_directory(path)) {
-        LOG_INFO << "Serving existing file: " << path;
-        auto resp = HttpResponse::newFileResponse(path);
-        if (hasExtension(path, ".png")) resp->setContentTypeCode(CT_IMAGE_PNG);
-        else if (hasExtension(path, ".csv")) resp->setContentTypeCode(CT_TEXT_CSV);
-        else if (hasExtension(path, ".dat")) resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
-        else resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
-        callback(resp);
-        return;
-    }
+	if (!fs::exists(path) || fs::is_directory(path))
+	{
+		Utils::AddMissingDlcFile(rq->getPath());
+		callback(HttpResponse::newNotFoundResponse());
+		return;
+	}
 
-    Utils::AddMissingDlcFile(rq->getPath());
-    LOG_INFO << "Generating placeholder for: " << path;
-
-    try {
-        fs::path dirPath = path.substr(0, path.find_last_of('/'));
-        if (!dirPath.empty() && !fs::exists(dirPath)) {
-            fs::create_directories(dirPath);
-        }
-
-        std::ofstream outFile(path, std::ios::binary);
-        if (outFile.is_open()) {
-            if (hasExtension(path, ".png")) {
-                std::string filename = rq->getPath().substr(rq->getPath().find_last_of('/') + 1);
-                int width = 1, height = 1;
-                parseDimensions(filename, width, height);
-                auto placeholderPng = generatePlaceholderPng(width, height);
-                outFile.write(placeholderPng.data(), placeholderPng.size());
-            }
-            else if (hasExtension(path, ".csv")) {
-                std::string placeholderCsv = "placeholder,data\n1,2";
-                outFile.write(placeholderCsv.data(), placeholderCsv.size());
-            }
-            else if (hasExtension(path, ".dat")) {
-                std::string placeholderDat = "placeholder_binary_data";
-                outFile.write(placeholderDat.data(), placeholderDat.size());
-            }
-            else {
-                std::string placeholderGeneric = "placeholder";
-                outFile.write(placeholderGeneric.data(), placeholderGeneric.size());
-            }
-            outFile.close();
-            LOG_INFO << "Generated placeholder for: " << path;
-        }
-        else {
-            LOG_ERROR << "Failed to create placeholder: " << path;
-            callback(HttpResponse::newNotFoundResponse());
-            return;
-        }
-
-        auto resp = HttpResponse::newFileResponse(path);
-        if (hasExtension(path, ".png")) resp->setContentTypeCode(CT_IMAGE_PNG);
-        else if (hasExtension(path, ".csv")) resp->setContentTypeCode(CT_TEXT_CSV);
-        else if (hasExtension(path, ".dat")) resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
-        else resp->setContentTypeCode(CT_APPLICATION_OCTET_STREAM);
-        callback(resp);
-    }
-    catch (const std::exception& e) {
-        LOG_ERROR << "Error generating placeholder: " << e.what();
-        callback(HttpResponse::newNotFoundResponse());
-    }
+	callback(HttpResponse::newFileResponse(path));
 }
 
 void BfWebController::HandleDefault(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
 {
-    Utils::DumpInfoToDrogon(rq, "WebController");
-    callback(HttpResponse::newHttpResponse());
+	Utils::DumpInfoToDrogon(rq, "WebController");
+	callback(HttpResponse::newHttpResponse());
 }

--- a/gimuserver/static_web/BfWebController.cpp.bak
+++ b/gimuserver/static_web/BfWebController.cpp.bak
@@ -1,0 +1,177 @@
+#include "BfWebController.hpp"
+#include "core/Utils.hpp"
+#include "core/System.hpp"
+#include "WebTerms.hpp"
+
+#include <drogon/HttpResponse.h>
+#include <filesystem>
+#include <fstream>
+#include <vector>
+
+using namespace drogon;
+namespace fs = std::filesystem;
+
+// Parse dimensions from filename (e.g., "MapVillage_640x0809.png" -> 640, 809)
+bool parseDimensions(const std::string& filename, int& width, int& height) {
+    size_t lastUnderscore = filename.find_last_of('_');
+    size_t dotPos = filename.find_last_of('.');
+    if (lastUnderscore == std::string::npos || dotPos == std::string::npos || lastUnderscore >= dotPos) {
+        return false;
+    }
+
+    std::string dimStr = filename.substr(lastUnderscore + 1, dotPos - lastUnderscore - 1);
+    size_t xPos = dimStr.find('x');
+    if (xPos == std::string::npos) return false;
+
+    try {
+        width = std::stoi(dimStr.substr(0, xPos));
+        height = std::stoi(dimStr.substr(xPos + 1));
+        return true;
+    }
+    catch (...) {
+        return false;
+    }
+}
+
+// Generate a minimal PNG with specified dimensions
+std::vector<char> generatePlaceholderPng(int width, int height) {
+    std::vector<char> pngData;
+
+    // PNG signature
+    const char signature[] = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
+    pngData.insert(pngData.end(), signature, signature + 8);
+
+    // IHDR chunk
+    uint32_t ihdrLength = htonl(13);
+    pngData.insert(pngData.end(), (char*)&ihdrLength, (char*)&ihdrLength + 4);
+    const char ihdrType[] = "IHDR";
+    pngData.insert(pngData.end(), ihdrType, ihdrType + 4);
+
+    uint32_t w = htonl(width);
+    uint32_t h = htonl(height);
+    pngData.insert(pngData.end(), (char*)&w, (char*)&w + 4);
+    pngData.insert(pngData.end(), (char*)&h, (char*)&h + 4);
+
+    const char ihdrData[] = { 8, 2, 0, 0, 0 }; // Bit depth 8, RGB, no compression, filter, interlace
+    pngData.insert(pngData.end(), ihdrData, ihdrData + 5);
+
+    uint32_t ihdrCrc = htonl(0); // Simplified CRC
+    pngData.insert(pngData.end(), (char*)&ihdrCrc, (char*)&ihdrCrc + 4);
+
+    // IDAT chunk (minimal data for a blank image)
+    uint32_t idatLength = htonl(12 + width * 4 * height); // Adjust length based on dimensions
+    pngData.insert(pngData.end(), (char*)&idatLength, (char*)&idatLength + 4);
+    const char idatType[] = "IDAT";
+    pngData.insert(pngData.end(), idatType, idatType + 4);
+
+    // Minimal data: transparent pixels (RGBA)
+    std::vector<char> idatData;
+    for (int y = 0; y < height; ++y) {
+        idatData.push_back(0); // Filter type
+        for (int x = 0; x < width; ++x) {
+            idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); idatData.push_back(0); // Transparent
+        }
+    }
+    pngData.insert(pngData.end(), idatData.begin(), idatData.end());
+
+    uint32_t idatCrc = htonl(0);
+    pngData.insert(pngData.end(), (char*)&idatCrc, (char*)&idatCrc + 4);
+
+    // IEND chunk
+    uint32_t iendLength = htonl(0);
+    pngData.insert(pngData.end(), (char*)&iendLength, (char*)&iendLength + 4);
+    const char iendType[] = "IEND";
+    pngData.insert(pngData.end(), iendType, iendType + 4);
+    uint32_t iendCrc = htonl(0);
+    pngData.insert(pngData.end(), (char*)&iendCrc, (char*)&iendCrc + 4);
+
+    return pngData;
+}
+
+void BfWebController::HandleWebPage(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    Utils::DumpInfoToDrogon(rq, "ProxyController");
+
+    // Special case for terms (if still needed by the mobile client)
+    if (rq->getPath() == "/bf/web/terms.htm") {
+        auto resp = HttpResponse::newHttpResponse();
+        resp->setBody(WEB_TERMS_DATA);
+        resp->setContentTypeCode(CT_TEXT_HTML); // Explicitly set for terms
+        callback(resp);
+        return;
+    }
+
+    // Construct the full filesystem path
+    auto path = System::Instance().GetContentRootPath() + rq->getPath();
+    LOG_INFO << "Requesting path: " << path;
+
+    // Serve existing file if it exists
+    if (fs::exists(path) && !fs::is_directory(path)) {
+        LOG_INFO << "Serving existing file: " << path;
+        auto resp = HttpResponse::newFileResponse(path);
+        // Let Drogon handle content type automatically based on extension
+        callback(resp);
+        return;
+    }
+
+    // Log missing asset and generate placeholder
+    Utils::AddMissingDlcFile(rq->getPath());
+    LOG_INFO << "Generating placeholder for: " << path;
+
+    try {
+        // Ensure directory exists
+        fs::path dirPath = path.substr(0, path.find_last_of('/'));
+        if (!dirPath.empty() && !fs::exists(dirPath)) {
+            fs::create_directories(dirPath);
+        }
+
+        std::ofstream outFile(path, std::ios::binary);
+        if (!outFile.is_open()) {
+            LOG_ERROR << "Failed to create placeholder: " << path;
+            callback(HttpResponse::newNotFoundResponse());
+            return;
+        }
+
+        // Generate placeholder based on file extension
+        std::string filename = rq->getPath().substr(rq->getPath().find_last_of('/') + 1);
+        if (filename.find(".png") != std::string::npos) {
+            int width = 1, height = 1;
+            parseDimensions(filename, width, height);
+            auto placeholderPng = generatePlaceholderPng(width, height);
+            outFile.write(placeholderPng.data(), placeholderPng.size());
+        }
+        else if (filename.find(".csv") != std::string::npos) {
+            std::string placeholderCsv = "id,value\n0,placeholder";
+            outFile.write(placeholderCsv.data(), placeholderCsv.size());
+        }
+        else if (filename.find(".dat") != std::string::npos) {
+            std::string placeholderDat = "placeholder_game_data";
+            outFile.write(placeholderDat.data(), placeholderDat.size());
+        }
+        else {
+            std::string placeholderGeneric = "placeholder";
+            outFile.write(placeholderGeneric.data(), placeholderGeneric.size());
+        }
+        outFile.close();
+        LOG_INFO << "Generated placeholder for: " << path;
+
+        // Serve the newly created placeholder file
+        auto resp = HttpResponse::newFileResponse(path);
+        // Drogon will automatically detect MIME type from extension
+        callback(resp);
+    }
+    catch (const std::exception& e) {
+        LOG_ERROR << "Error generating placeholder: " << e.what();
+        callback(HttpResponse::newNotFoundResponse());
+    }
+}
+
+void BfWebController::HandleDefault(const HttpRequestPtr& rq, std::function<void(const HttpResponsePtr&)>&& callback)
+{
+    Utils::DumpInfoToDrogon(rq, "ProxyController");
+    // Return a minimal response for unhandled routes
+    auto resp = HttpResponse::newHttpResponse();
+    resp->setStatusCode(k200OK);
+    resp->setBody("Proxy server active");
+    callback(resp);
+}

--- a/gimuserver/static_web/BfWebController.cpp.bak
+++ b/gimuserver/static_web/BfWebController.cpp.bak
@@ -1,3 +1,4 @@
+// This is the code I had for file generation. Maybe worth a revisit later on. For now, I'm storing it as a .bak file.
 #include "BfWebController.hpp"
 #include "core/Utils.hpp"
 #include "core/System.hpp"

--- a/gimuserver/todo.txt
+++ b/gimuserver/todo.txt
@@ -1,1 +1,0 @@
-https://github.com/arves100/gimufrontier/blob/main/gimufrontier/Models/BF_Action/Responses/InitializeResponse.cs


### PR DESCRIPTION
Set unit limit to 500 for now to prevent annoying crash do to caching on the client. The current SQLite3 DB holds all ~1900 units (all unique units, no duplicates) for testing but I haven't been able to increase this value past ~1470 by slowly incrementing.

The increments per server and client load look sorta like this: 500(initial load) > 800 > 1000 > 1200 > 1300 > 1340 > 1380 > Unstable all the way to ~1470.

Currently looking into server to client warning to tell the client to "stall" in order to load variables in the unit's page, or handle it with streaming to avoid the heap overflow that I suspect to be happening currently. 

There is also an issue I'll open once this PR goes through for duplicate unit architecture. The current unit database comes from another community repo detailing the unit's JSON which I have loaded into the created table.

I also redid the user's ID to mesh across the whole server repo better and allow for user creation MST setup in the future using the current placeholder as the fallback.