### PR TITLE
Build: drop glaze /GL+/LTCG so MSVC Release links

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,19 @@ find_package(Drogon CONFIG REQUIRED)
 find_package(unofficial-sqlite3 CONFIG REQUIRED)
 find_package(glaze CONFIG REQUIRED) # c++ JSON abstraction
 
+# glaze's vcpkg port pins /GL (whole-program opt) and /LTCG on its imported
+# target for Release/MinSizeRel.  Those flags propagate through gimuserver to
+# every consumer, and MSVC's LTCG code-gen pass chokes on the coroutine
+# HANDLEF bodies (e.g. UserInfo.cpp, GachaAction.cpp) with C4737 -> LNK1257.
+# Drop the LTCG flags so Release links cleanly.  We give up cross-TU inlining
+# from glaze; the tradeoff is the build actually completing.
+if (MSVC AND TARGET glaze::glaze)
+    set_property(TARGET glaze::glaze PROPERTY INTERFACE_COMPILE_OPTIONS
+        "/Zc:preprocessor;/permissive-;/Zc:lambda")
+    set_property(TARGET glaze::glaze PROPERTY INTERFACE_LINK_OPTIONS
+        "$<$<CONFIG:Release>:/INCREMENTAL:NO>;$<$<CONFIG:MinSizeRel>:/INCREMENTAL:NO>")
+endif()
+
 add_subdirectory(packet-generator/assets/runtime/cpp)
 add_subdirectory(gimuserver)
 


### PR DESCRIPTION
glaze's vcpkg port pins `/GL` (whole-program optimization) and `/LTCG` on its
imported target for Release/MinSizeRel. Those flags propagate through
`gimuserver` to every consumer, and MSVC's LTCG code-gen pass fails on the
coroutine `HANDLEF` bodies (e.g. `UserInfo.cpp`, `GachaAction.cpp`) with
`C4737 → LNK1257`, so Release / MinSizeRel builds don't link.

This overrides glaze's interface compile/link options to drop the LTCG flags.
The tradeoff is losing cross-TU inlining from glaze in exchange for Release
actually linking. Debug builds are unaffected.

Split out of a larger feature branch (per review feedback) as a standalone,
independent build fix.
