### PR TITLE
handlers: V2 summon ticket inventory

### DIFF
--- a/gimuserver/gme/handlers/GmeControllerHandlers.cpp
+++ b/gimuserver/gme/handlers/GmeControllerHandlers.cpp
@@ -77,6 +77,7 @@ static GmeHandler getHandler(std::string_view cmd)
 	REGISTER("2o4axPIC", FriendGet, "EoYuZ2nbImhCU1c0");
 	REGISTER("F7JvPk5H", GachaAction, "bL9fipzaSy7xN2w1");
 	REGISTER("Uo86DcRh", GachaList, "8JbxFvuSaB2CK7Ln");
+	REGISTER("k57TdKDj", UnitSelectorGachaTicket, "1IJ8SaNk");
 	REGISTER("NiYWKdzs", HomeInfo, "f6uOewOD");
 	REGISTER("9TvyNR5H", MissionEnd, "oINq0rfUFPx5MgmT");
 	REGISTER("jE6Sp0q4", MissionStart, "csiVLDKkxEwBfR70");
@@ -86,6 +87,7 @@ static GmeHandler getHandler(std::string_view cmd)
 	REGISTER("T1nCVvx4", TutorialUpdate, "7hqzmR3T");
 	REGISTER("ynB7X5P9", UpdateInfoLight, "7kH9NXwC");
 	REGISTER("cTZ3W2JG", UserInfo, "ScJx6ywWEb0A3njT");
+
 
 	}
 }
@@ -150,6 +152,7 @@ drogon::Task<GmeAction> GmeController::Handle(drogon::SessionPtr session, const 
 			catch (const drogon::orm::DrogonDbException& ex)
 			{
 				LOG_ERROR << "Handler error " << header.id << " (" << handler.name << ") database exception: " << ex.base().what();
+				logReq << "EXCEPTION (db): " << ex.base().what() << "\n";
 				GmeError err{};
 				err.cmd = GmeErrorCommand::Close;
 				err.flag = GmeErrorFlags::IsInError;
@@ -159,6 +162,7 @@ drogon::Task<GmeAction> GmeController::Handle(drogon::SessionPtr session, const 
 			catch (const std::exception& ex)
 			{
 				LOG_ERROR << "Handler error " << header.id << " (" << handler.name << ") exception: " << ex.what();
+				logReq << "EXCEPTION (std): " << ex.what() << "\n";
 				GmeError err{};
 				err.cmd = GmeErrorCommand::Close;
 				err.flag = GmeErrorFlags::IsInError;

--- a/gimuserver/gme/handlers/Handlers.hpp
+++ b/gimuserver/gme/handlers/Handlers.hpp
@@ -87,6 +87,7 @@ namespace GmeHandlers
 	HANDLE(FriendGet);
 	HANDLE(GachaAction);
 	HANDLE(GachaList);
+	HANDLE(UnitSelectorGachaTicket);
 	HANDLE(HomeInfo);
 	HANDLE(MissionEnd);
 	HANDLE(MissionStart);

--- a/gimuserver/gme/handlers/UnitSelectorGachaTicket.cpp
+++ b/gimuserver/gme/handlers/UnitSelectorGachaTicket.cpp
@@ -1,0 +1,37 @@
+#include "App.hpp"
+#include "Handlers.hpp"
+
+// UnitSelectorGachaTicket — handler stub for the "use a Unit Selector Gacha
+// Ticket" client request.  Triggered by the user tapping a per-door ticket
+// button on a selector gacha (e.g. the Burst Heroes Selector banner under
+// the Veteran summon category).
+//
+// GroupId  = "k57TdKDj"
+// AES key  = "1IJ8SaNk"
+// (per BraveFrontier IDA readParam and Handler exports.../UnitSelectorGachaTicketRequestHandler.hpp)
+//
+// Request shape (from bfdata/createbody/UnitSelectorGachaTicketRequest.txt):
+//   "CGHaOZda": [{
+//     "7Ffmi96v": "<gacha_id>",      target gacha door
+//     "XIvaD6Jp": "<selector_id>",   which selector entry within that gacha
+//     "pn16CNah": "<unit_id>",       the unit the user picked from the pool
+//     "H6k1LIxC": "<?>",             unknown — possibly count or ticket-id
+//     "C5QbG2DM": "<?>",             unknown — possibly cost
+//   }]
+//
+// Response: empty `{}` for now.  The full flow needs:
+//   1. Verify the user owns at least one matching V2 ticket
+//   2. INSERT the selected unit into user_units
+//   3. Decrement user_summon_tickets_v2 for the ticket type
+//   4. Return UserUnitInfo + UnitSelectorGachaUserInfoResponse (CGHaOZda)
+//
+// Even an empty `{}` is useful as a registration test — the BF client may
+// hide UI elements whose target endpoint isn't registered on the server
+// (since tapping would error out).  See handbook §7.11.6 for the broader
+// "use ticket" button-visibility investigation.
+HANDLEF(UnitSelectorGachaTicket)
+{
+    (void)session;
+    LOG_INFO << "UnitSelectorGachaTicket (stub): " << json;
+    co_return HandleResult::success("{}");
+}


### PR DESCRIPTION
# handlers: V2 summon ticket inventory

**Branch:** `split/07-summoning`  
**Base:** `dev`  
**Merge position:** 07 of 13

> Part of the PR #28 split. Each PR branches from `dev` and contains only its
> own changes, so this diff is exactly one subsystem. The set is designed to be
> merged in numeric order; merging all 13 reproduces PR #28 byte for byte
> (verified against tree `79a4e065`).
>
> Later PRs in the series touch `Handlers.hpp`, `GmeControllerHandlers.cpp` and
> `UserInfo.cpp` too, so once earlier ones land this branch may need a rebase.
> Those conflicts are always additions on both sides — keep both. Maintainer
> edits are enabled, so feel free to push the rebase directly to this branch.

Smallest PR in the series — one handler and one table.

### What's included

- **`UnitSelectorGachaTicket`** (`k57TdKDj`) — redeem V2 typed summon tickets.
- **`user_summon_tickets_v2`** table (migration landed in PR 3).

### Note on scope

The archive-driven summoning path itself is **not** in this PR. `GachaAction` and `GachaList` already live on the helper layer upstream and were adopted wholesale during the merge, so they don't appear in the diff against `dev` at all. This only adds the typed-ticket entry point alongside them.

### Verification

Redeem a ticket, confirm the count decrements and the unit is granted.
